### PR TITLE
Added TCK tests for Subscriber and Processor.

### DIFF
--- a/src/main/java/rx/internal/SubjectProcessor.java
+++ b/src/main/java/rx/internal/SubjectProcessor.java
@@ -1,0 +1,61 @@
+package rx.internal;
+
+import org.reactivestreams.Processor;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import rx.observers.Subscribers;
+import rx.subjects.Subject;
+
+/**
+ * The {@link SubjectProcessor} wraps a {@link Subject}.
+ */
+public class SubjectProcessor<T, R> implements Processor<T, R> {
+
+    /**
+     * The wrapped Rx {@link Subject} as a {@link Subscriber}.
+     */
+    private final Subscriber<T> subscriber;
+
+    /**
+     * The wrapped Rx {@link Subject} as a {@link Publisher}.
+     */
+    private final Publisher<R> publisher;
+
+    /**
+     * Creates a new {@link SubjectProcessor}.
+     *
+     * @param subject the wrapped {@link Subject}.
+     */
+    public SubjectProcessor(final Subject<T, R> subject) {
+        this.subscriber = new PublisherSubscriber<T>(Subscribers.from(subject));
+        this.publisher = new ObservablePublisher<R>(subject);
+    }
+
+    @Override
+    public void onSubscribe(Subscription s) {
+        subscriber.onSubscribe(s);
+    }
+
+    @Override
+    public void onNext(T t) {
+        subscriber.onNext(t);
+    }
+
+    @Override
+    public void onError(Throwable t) {
+        subscriber.onError(t);
+    }
+
+    @Override
+    public void onComplete() {
+        subscriber.onComplete();
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super R> s) {
+        publisher.subscribe(s);
+    }
+
+}

--- a/src/test/java/rx/RxIdentityProcessorTest.java
+++ b/src/test/java/rx/RxIdentityProcessorTest.java
@@ -1,20 +1,28 @@
 package rx;
 
+import org.reactivestreams.Processor;
 import org.reactivestreams.Publisher;
-import org.reactivestreams.tck.PublisherVerification;
+import org.reactivestreams.tck.IdentityProcessorVerification;
 import org.reactivestreams.tck.TestEnvironment;
 import org.testng.annotations.Test;
 
+import rx.internal.SubjectProcessor;
+import rx.subjects.PublishSubject;
 import rx.test.IterableDecrementer;
 
-@Test // needed for Gradle to find this as a test
-public class RxPublisherTest extends PublisherVerification<Integer> {
+@Test
+public class RxIdentityProcessorTest extends IdentityProcessorVerification<Integer> {
 
     public static final long DEFAULT_TIMEOUT_MILLIS = 300L;
     public static final long PUBLISHER_REFERENCE_CLEANUP_TIMEOUT_MILLIS = 1000L;
 
-    public RxPublisherTest() {
+    public RxIdentityProcessorTest() {
         super(new TestEnvironment(DEFAULT_TIMEOUT_MILLIS), PUBLISHER_REFERENCE_CLEANUP_TIMEOUT_MILLIS);
+    }
+
+    @Override
+    public Processor<Integer, Integer> createIdentityProcessor(int bufferSize) {
+        return new SubjectProcessor<Integer, Integer>(PublishSubject.<Integer> create());
     }
 
     @Override
@@ -23,13 +31,13 @@ public class RxPublisherTest extends PublisherVerification<Integer> {
     }
 
     @Override
-    public Publisher<Integer> createPublisher(long elements) {
+    public Publisher<Integer> createHelperPublisher(long elements) {
         return RxReactiveStreams.<Integer>toPublisher(Observable.from(new IterableDecrementer(elements)));
     }
 
     @Override
     public Publisher<Integer> createErrorStatePublisher() {
-        return RxReactiveStreams.<Integer>toPublisher(Observable.<Integer>error(new Exception("!")));
+        return RxReactiveStreams.<Integer>toPublisher(Observable.<Integer> error(new Exception("!")));
     }
 
 }

--- a/src/test/java/rx/RxSubscriberBlackboxTest.java
+++ b/src/test/java/rx/RxSubscriberBlackboxTest.java
@@ -1,0 +1,33 @@
+package rx;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.tck.SubscriberBlackboxVerification;
+import org.reactivestreams.tck.TestEnvironment;
+import org.testng.annotations.Test;
+
+import rx.internal.PublisherSubscriber;
+import rx.observers.EmptyObserver;
+import rx.observers.Subscribers;
+import rx.test.IterableDecrementer;
+
+@Test
+public class RxSubscriberBlackboxTest extends SubscriberBlackboxVerification<Integer> {
+
+    public static final long DEFAULT_TIMEOUT_MILLIS = 300L;
+
+    protected RxSubscriberBlackboxTest() {
+        super(new TestEnvironment(DEFAULT_TIMEOUT_MILLIS));
+    }
+
+    @Override
+    public Subscriber<Integer> createSubscriber() {
+        return new PublisherSubscriber<Integer>(Subscribers.from(new EmptyObserver<Integer>()));
+    }
+
+    @Override
+    public Publisher<Integer> createHelperPublisher(long elements) {
+        return RxReactiveStreams.<Integer>toPublisher(Observable.from(new IterableDecrementer(elements)));
+    }
+
+}

--- a/src/test/java/rx/RxSubscriberWhiteboxTest.java
+++ b/src/test/java/rx/RxSubscriberWhiteboxTest.java
@@ -1,0 +1,64 @@
+package rx;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import org.reactivestreams.tck.SubscriberWhiteboxVerification;
+import org.reactivestreams.tck.TestEnvironment;
+import org.testng.annotations.Test;
+
+import rx.internal.PublisherSubscriber;
+import rx.observers.EmptyObserver;
+import rx.observers.Subscribers;
+import rx.test.IterableDecrementer;
+
+@Test
+public class RxSubscriberWhiteboxTest extends SubscriberWhiteboxVerification<Integer> {
+
+    public static final long DEFAULT_TIMEOUT_MILLIS = 300L;
+
+    protected RxSubscriberWhiteboxTest() {
+        super(new TestEnvironment(DEFAULT_TIMEOUT_MILLIS));
+    }
+
+    @Override
+    public Subscriber<Integer> createSubscriber(final WhiteboxSubscriberProbe<Integer> probe) {
+        return new PublisherSubscriber<Integer>(Subscribers.from(new EmptyObserver<Integer>())) {
+            @Override
+            public void onSubscribe(final Subscription rsSubscription) {
+                probe.registerOnSubscribe(new SubscriberPuppet() {
+                    @Override
+                    public void triggerRequest(long elements) {
+                        rsSubscription.request(elements);
+                    }
+
+                    @Override
+                    public void signalCancel() {
+                        rsSubscription.cancel();
+                    }
+                });
+            }
+
+            @Override
+            public void onNext(Integer t) {
+                probe.registerOnNext(t);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                probe.registerOnError(t);
+            }
+
+            @Override
+            public void onComplete() {
+                probe.registerOnComplete();
+            }
+        };
+    }
+
+    @Override
+    public Publisher<Integer> createHelperPublisher(long elements) {
+        return RxReactiveStreams.<Integer>toPublisher(Observable.from(new IterableDecrementer(elements)));
+    }
+
+}

--- a/src/test/java/rx/test/IterableDecrementer.java
+++ b/src/test/java/rx/test/IterableDecrementer.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.test;
+
+import java.util.Iterator;
+
+/**
+ * Iterates from some arbitrary starting value down to 0, or forever if the starting value is
+ * Long.MAX_VALUE.
+ */
+public class IterableDecrementer implements Iterable<Integer> {
+
+    private final long from;
+
+    /**
+     * Creates new {@link IterableDecrementer}.
+     *
+     * @param from the value to start from. If equal to Long.MAX_VALUE, iteration never stops.
+     */
+    public IterableDecrementer(final long from) {
+        if (from < 0) {
+            throw new IllegalArgumentException("from < 0");
+        }
+        this.from = from;
+    }
+
+    @Override
+    public Iterator<Integer> iterator() {
+        return new Repeater((int) from);
+    }
+
+    class Repeater implements Iterator<Integer> {
+
+        private int i;
+
+        public Repeater(final int repeats) {
+            i = repeats;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return i > 0 || from == Long.MAX_VALUE;
+        }
+
+        @Override
+        public Integer next() {
+            return --i;
+        }
+
+        @Override
+        public void remove() {
+            throw new UnsupportedOperationException();
+        }
+
+    }
+}


### PR DESCRIPTION
I've hooked Subscriber into SubscriberBlackboxVerification and SubscriberWhiteboxVerification. I also attempted at creating a SubjectProcessor class which wraps a Subject and uses it as a Processor, but I keep getting wierd test results.

Lastly, I haven't yet figured out a good way to actually test the concrete onSubscribe handler, which can be seen [here](https://github.com/emanuelpalm/RxJavaReactiveStreams/blob/7e93f9881c2dba35596501eb7ea88d60c212ba09/src/test/java/rx/RxSubscriberWhiteboxTest.java#L29).

If this seems like a good start, then go ahead and merge on. Either way I would gladly accept some thoughts or guidelines I could continue to work with.

By the way, current rest results are as follows:

152 tests completed, 22 failed, 59 skipped
