### PR TITLE
Example non-blocking producer+subscription for wrapping rs

### DIFF
--- a/rxjava-reactive-streams/src/main/java/rx/internal/reactivestreams/RxJavaAtomicProducer.java
+++ b/rxjava-reactive-streams/src/main/java/rx/internal/reactivestreams/RxJavaAtomicProducer.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.internal.reactivestreams;
+
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.reactivestreams.Subscription;
+
+public final class RxJavaAtomicProducer extends AtomicInteger implements rx.Producer, rx.Subscription {
+    /** */
+    private static final long serialVersionUID = -8651615387948310062L;
+    final Subscription subscription;
+    final ConcurrentLinkedQueue<Long> requests;
+    volatile boolean unsubscribed;
+    public RxJavaAtomicProducer(Subscription subscription) {
+        if (subscription == null) {
+            throw new NullPointerException("subscription");
+        }
+        this.subscription = subscription;
+        this.requests = new ConcurrentLinkedQueue<Long>();
+    }
+    @Override
+    public void request(long n) {
+        if (n > 0 && !unsubscribed) {
+            requests.offer(n);
+            if (getAndIncrement() == 0) {
+                do {
+                    Long v = requests.poll();
+                    // v may be null if unsubscribe() cleared the queue while draining
+                    if (v == null || v == 0L) {
+                        unsubscribed = true;
+                        subscription.cancel();
+                        requests.clear();
+                        return;
+                    } else {
+                        subscription.request(n);
+                    }
+                } while (decrementAndGet() > 0);
+            }
+        }
+    }
+    @Override
+    public void unsubscribe() {
+        if (!unsubscribed) {
+            requests.clear();
+            requests.offer(0L);
+            if (getAndIncrement() == 0) {
+                unsubscribed = true;
+                subscription.cancel();
+                requests.clear();
+            }
+        }
+    }
+    @Override
+    public boolean isUnsubscribed() {
+        return unsubscribed;
+    }
+}

--- a/rxjava-reactive-streams/src/main/java/rx/internal/reactivestreams/SubscriberAdapter.java
+++ b/rxjava-reactive-streams/src/main/java/rx/internal/reactivestreams/SubscriberAdapter.java
@@ -39,21 +39,10 @@ public class SubscriberAdapter<T> implements Subscriber<T> {
         }
 
         if (started.compareAndSet(false, true)) {
-            rxSubscriber.add(Subscriptions.create(new Action0() {
-                @Override
-                public void call() {
-                    rsSubscription.cancel();
-                }
-            }));
+            RxJavaAtomicProducer ap = new RxJavaAtomicProducer(rsSubscription);
+            rxSubscriber.add(ap);
             rxSubscriber.onStart();
-            rxSubscriber.setProducer(new Producer() {
-                @Override
-                public void request(long n) {
-                    if (n > 0) {
-                        rsSubscription.request(n);
-                    }
-                }
-            });
+            rxSubscriber.setProducer(ap);
         } else {
             rsSubscription.cancel();
         }


### PR DESCRIPTION
Subscriptions.

Another example by using non-blocking queue-drain logic for serializing access to the methods of rs.Subscription.

There is room for improvements:
- by using a primitive long-specialized MpscLinkedQueue implementation
- by adding a fast-path to the request() serialization in the form of a single cas (instead of the 1 atomic increment + 2 cas inside the CLQ).
