### PR TITLE
Upgrade to RxJava 1.3.5, RS 1.0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-- oraclejdk7
+- oraclejdk8
 sudo: false
 # as per http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/
 

--- a/rxjava-reactive-streams/build.gradle
+++ b/rxjava-reactive-streams/build.gradle
@@ -4,10 +4,10 @@ apply plugin: 'java'
 apply plugin: 'jacoco'
 
 dependencies {
-    compile 'io.reactivex:rxjava:1.2.2'
-    compile 'org.reactivestreams:reactive-streams:1.0.0'
-    testCompile 'org.reactivestreams:reactive-streams-tck:1.0.0'
-    testCompile group: 'org.testng', name: 'testng', version: '6.9.10'
+    compile 'io.reactivex:rxjava:1.3.5'
+    compile 'org.reactivestreams:reactive-streams:1.0.2'
+    testCompile 'org.reactivestreams:reactive-streams-tck:1.0.2'
+    testCompile group: 'org.testng', name: 'testng', version: '6.11'
 }
 
 test {
@@ -29,7 +29,7 @@ useTestNG()
 
 
 jacoco {
-    toolVersion = '0.7.7.201606060606' // See http://www.eclemma.org/jacoco/.
+    toolVersion = '0.7.9' // See http://www.eclemma.org/jacoco/.
 }
 
 jacocoTestReport {

--- a/rxjava-reactive-streams/src/main/java/rx/RxReactiveStreams.java
+++ b/rxjava-reactive-streams/src/main/java/rx/RxReactiveStreams.java
@@ -54,7 +54,7 @@ public abstract class RxReactiveStreams {
      * @return the converted {@link Observable}
      */
     public static <T> Observable<T> toObservable(final Publisher<T> publisher) {
-        return Observable.create(new Observable.OnSubscribe<T>() {
+        return Observable.unsafeCreate(new Observable.OnSubscribe<T>() {
             @Override
             public void call(final rx.Subscriber<? super T> rxSubscriber) {
                 publisher.subscribe(toSubscriber(rxSubscriber));

--- a/rxjava-reactive-streams/src/test/java/rx/reactivestreams/NonTckTest.java
+++ b/rxjava-reactive-streams/src/test/java/rx/reactivestreams/NonTckTest.java
@@ -103,7 +103,7 @@ public class NonTckTest {
 
     @Test
     void rxFailingOnSubscribeSendsSingleErrorPostSubscribe() {
-        RsSubscriber<Integer> subscriber = subscribe(Observable.create(new Observable.OnSubscribe<Integer>() {
+        RsSubscriber<Integer> subscriber = subscribe(Observable.unsafeCreate(new Observable.OnSubscribe<Integer>() {
             @Override
             public void call(Subscriber<? super Integer> subscriber) {
                 throw new RuntimeException("!");


### PR DESCRIPTION
This PR updates the dependencies to RxJava 1.3.5, Reactive Streams 1.0.2, TestNG 6.11, Jacococ Coverage to 0.7.9 and updates the usage of the now-deprecated `create` overload.